### PR TITLE
Add a link to the ITPUG website

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,6 +9,7 @@
         <ul>
           <li><a href="{{site.baseurl}}/">Blog</a></li>
           <li><a href="{{site.baseurl}}/about">Chi siamo</a></li>
+          <li><a href="https://new.itpug.org/">IT-PUG associazione</a></li>
         </ul>
       </nav>
       <p class="logo"><a href="{{site.baseurl}}/">{{ site.author }}</a></p>


### PR DESCRIPTION
I'd propose to add a link to the ITPUG website from the blog, since there is a direct link from the former to the latter. Could be nice to have a way to come back.

Let me know what do you think.